### PR TITLE
chore: Update Node.js to 20.44.1

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-nodejs 20.18.0
+nodejs 20.44.1
 pnpm 9.12.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ###
 # Use Node.js
-FROM node:20.18.0-bookworm-slim AS base
+FROM node:20.44.1-bookworm-slim AS base
 WORKDIR /app
 
 # Installs


### PR DESCRIPTION
Update versions
- Node.js: 20.18.0 -> 20.44.1